### PR TITLE
Implement support for buttons

### DIFF
--- a/src/controller.c
+++ b/src/controller.c
@@ -58,12 +58,12 @@ struct Controller {
 static struct Controller controller;
 
 /* Currently we have a static map for SkyController 2 */
-static const int evdev_mapping[] = {
+static const int evdev_axis_mapping[] = {
     [AXIS_ROLL] = ABS_Z, [AXIS_PITCH] = ABS_RX,    [AXIS_THROTTLE] = ABS_Y,
     [AXIS_YAW] = ABS_X,  [AXIS_AUX_LEFT] = ABS_RY,
 };
 
-static uint16_t controller_scale(struct Controller *c, enum Axis axis, int val)
+static uint16_t controller_abs_scale(struct Controller *c, enum Axis axis, int val)
 {
     int rmin = c->info.range[axis][INFO_ABS_MIN];
     int rmax = c->info.range[axis][INFO_ABS_MAX];
@@ -83,7 +83,7 @@ static int get_axis_from_evdev(unsigned long code)
     int e;
 
     for (e = 0; e < _AXIS_COUNT; e++)
-        if (evdev_mapping[e] == (int)code)
+        if (evdev_axis_mapping[e] == (int)code)
             return e;
 
     return -1;
@@ -174,7 +174,7 @@ static void evdev_handler(int fd, void *data, int ev_mask)
             continue;
         }
 
-        c->val[axis] = controller_scale(c, axis, e->value);
+        c->val[axis] = controller_abs_scale(c, axis, e->value);
 
         log_debug("received event axis=%d val=%u\n", axis, c->val[axis]);
     }


### PR DESCRIPTION
This allows to map buttons found on joysticks to a RC channel. Up to 9 buttons are supported. The way it works is that it considers the range as a bitmask, to be updated and sent to the flight stack to decide what actions to take. Since we normally have the range [1000 - 2000], this gives us 9 bits. If we extend the range a little bit it's also possible to report 10 (simultaneous) button events.

In the controller there's no notion of short or long press, which is left for the flight stack to define.

This was done at first for Sky Controller 2, with the events it generates on Linux input subsystem. In future, changing the button mapping it's possible to support additional controllers.  I expect this to work fine on any "IP-based" controller. If the RC is ppm, this may not work as even a 1-bit change due to jitter in the timing may screw the the values of the channel in a very bad way (e.g. detecting button presses when they aren't). One mitigation may be to ignore the first bits.

